### PR TITLE
Apply maintenance improvements for CRAN submission

### DIFF
--- a/R/generate-clusters.R
+++ b/R/generate-clusters.R
@@ -52,8 +52,11 @@ genclust <- function(x, nclust = 10, weights = NULL){
     stop("`x` must be of class `sf`, `sfc`, `matrix` or `Matrix`.")
   }
 
+  if (!is.numeric(nclust) || length(nclust) != 1 || nclust < 1) {
+    stop("`nclust` must be a positive integer.")
+  }
   if (nclust > dim(x)[1]) {
-    stop("`nclust` must be smaller that number of regions.")
+    stop("`nclust` must be smaller than number of regions.")
   }
 
   if (is.null(weights)) weights <- runif(length(x))

--- a/R/model-within.R
+++ b/R/model-within.R
@@ -167,13 +167,7 @@ correction_required <- function (formula) {
 #'
 #' @export
 data_all <- function(stdata, stnames = c("geometry", "time")) {
-  # check if the input is a stars object and dimension names
-  if (!inherits(stdata, "stars")) {
-    stop("Argument `stdata` must be a `stars` object.")
-  }
-  if (any(!(stnames %in% dimnames(stdata)))) {
-    stop("Provided dimension names in `stnames` not found in stars object `stdata`.")
-  }
+  validate_stdata_input(stdata, stnames)
 
   stdata[["id"]] <- 1:prod(dim(stdata))
 
@@ -186,6 +180,15 @@ data_all <- function(stdata, stnames = c("geometry", "time")) {
   # merge dimensions and dataframe
   stdata <- as.data.frame(stdata)
   cbind(stdata["id"], dims, stdata[, !names(stdata) %in% c("id", stnames[1])])
+}
+
+validate_stdata_input <- function(stdata, stnames) {
+  if (!inherits(stdata, "stars")) {
+    stop("Argument `stdata` must be a `stars` object.")
+  }
+  if (any(!(stnames %in% dimnames(stdata)))) {
+    stop("Provided dimension names in `stnames` not found in stars object `stdata`.")
+  }
 }
 
 #' Prepare data for a cluster
@@ -219,13 +222,7 @@ data_all <- function(stdata, stnames = c("geometry", "time")) {
 #'
 #' @export
 data_each <- function(k, membership, stdata, stnames = c("geometry", "time")) {
-  # check if the input is a stars object and dimension names
-  if (!inherits(stdata, "stars")) {
-    stop("Argument `stdata` must be a `stars` object.")
-  }
-  if (any(!(stnames %in% dimnames(stdata)))) {
-    stop("Provided dimension names in `stnames` not found in stars object `stdata`.")
-  }
+  validate_stdata_input(stdata, stnames)
 
   stdata[["id"]] <- 1:prod(dim(stdata))
 

--- a/R/sfclust-methods.R
+++ b/R/sfclust-methods.R
@@ -2,7 +2,7 @@
 #'
 #' Prints details of an sfclust object, including the (i) within-cluster formula;
 #' (ii) hyperparameters used for the MCMC sample such as the number of clusters penalty
-#' (q) and the movement probabilities (move_prob); (iii) the number of movement type dones
+#' (q) and the movement probabilities (move_prob); (iii) the number of movement type counts
 #' during the MCMC sampling; and (iv) the log marginal likelihood of the model of the last
 #' clustering sample.
 #'
@@ -110,7 +110,7 @@ sort_membership <- function(x) {
 #'
 #' @details This function takes the last state of the Markov chain from a previous
 #'          `sfclust` execution and uses it as the starting point for additional MCMC
-#'          iterations. If `sample` is provided, it simply udpates the within-cluster
+#'          iterations. If `sample` is provided, it simply updates the within-cluster
 #'          models for the specified clustering `sample`.
 #'
 #' @return An updated `sfclust` object with (i) new clustering samples if `sample` is not
@@ -122,7 +122,7 @@ sort_membership <- function(x) {
 update.sfclust <- function(object, niter = 100, burnin = 0, thin = 1, nmessage = 10, sample = NULL,
                            path_save = NULL, nsave = nmessage, ...) {
   if (!is.null(sample)) {
-    update_within(object, nrow(object$samples$membership))
+    update_within(object, sample)
   } else {
     update_sfclust(object, niter, burnin, thin, nmessage, path_save, nsave)
   }

--- a/R/spanning-tree.R
+++ b/R/spanning-tree.R
@@ -28,7 +28,7 @@ splitCluster <- function(mstgraph, k, membership) {
   edge_cutted <- sample.int(tcluster[clust.split] - 1, 1)
 
   mst_subgraph <- igraph::induced_subgraph(mstgraph, membership == clust.split)
-  mst_subgraph <- delete.edges(mst_subgraph, edge_cutted)
+  mst_subgraph <- delete_edges(mst_subgraph, edge_cutted)
   connect_comp <- components(mst_subgraph)
   cluster_new <- connect_comp$membership
   vid_new <- (V(mst_subgraph)$vid)[cluster_new == 2] # vid for vertices belonging to new cluster

--- a/man/print.sfclust.Rd
+++ b/man/print.sfclust.Rd
@@ -24,7 +24,7 @@ prints a summary of:
 \description{
 Prints details of an sfclust object, including the (i) within-cluster formula;
 (ii) hyperparameters used for the MCMC sample such as the number of clusters penalty
-(q) and the movement probabilities (move_prob); (iii) the number of movement type dones
+(q) and the movement probabilities (move_prob); (iii) the number of movement type counts
 during the MCMC sampling; and (iv) the log marginal likelihood of the model of the last
 clustering sample.
 }

--- a/man/update.sfclust.Rd
+++ b/man/update.sfclust.Rd
@@ -49,6 +49,6 @@ provided.
 \details{
 This function takes the last state of the Markov chain from a previous
 \code{sfclust} execution and uses it as the starting point for additional MCMC
-iterations. If \code{sample} is provided, it simply udpates the within-cluster
+iterations. If \code{sample} is provided, it simply updates the within-cluster
 models for the specified clustering \code{sample}.
 }

--- a/tests/testthat/test-generate-clusters.R
+++ b/tests/testthat/test-generate-clusters.R
@@ -49,4 +49,9 @@ test_that("generate clusters", {
   # missspecified x
   expect_error(genclust("x", nclust = 5),
     "`x` must be of class `sf`, `sfc`, `matrix` or `Matrix`.")
+
+  # invalid nclust values
+  expect_error(genclust(x, nclust = 0), "`nclust` must be a positive integer.")
+  expect_error(genclust(x, nclust = -1), "`nclust` must be a positive integer.")
+  expect_error(genclust(x, nclust = "3"), "`nclust` must be a positive integer.")
 })


### PR DESCRIPTION
- Fix bug in update.sfclust() where sample argument was ignored and always defaulted to the last row instead of the requested sample
- Replace deprecated igraph delete.edges() with delete_edges()
- Add input validation to genclust() for invalid nclust values (<1, non-numeric, non-scalar); fix typo in error message
- Extract shared validate_stdata_input() helper to remove duplicated validation block between data_all() and data_each()
- Fix typos in roxygen docs: "udpates", "movement type dones", "smaller that"
- Add tests for new genclust() validation